### PR TITLE
Add Alertmanager cases and transposer

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "alertmanager",
+    "cases": ["single-open", "multi-open", "empty-open"]
+  },
+  {
     "name": "aws-sns",
     "cases": ["open", "confirm"]
   },

--- a/src/alertmanager.js
+++ b/src/alertmanager.js
@@ -1,0 +1,85 @@
+const md5 = require('md5');
+////////////////////
+// COPY FROM HERE //
+/*
+ * Transpose a payload from Alertmanager into a Signal
+ */
+function transpose(input) {
+  const payload = input.data;
+
+  let summary, body = '';
+  let links = [];
+
+  // Links
+  payload.alerts.forEach((alert) => {
+    if (alert.generatorURL) {
+      links.push({
+        href: alert.generatorURL,
+        text: `Generator URL${alert?.annotations?.summary ? ' - ' + alert.annotations.summary : ''}`
+      });
+    }
+  });
+
+  // Common Annotations
+  let annotations = {
+    'alertmanager/groupKey': payload.groupKey
+  };
+
+  if (payload?.commonAnnotations) {
+    annotations = {
+      ...Object.fromEntries(Object.entries(payload.commonAnnotations).map(([k, v]) => [`alertmanager/annotations-${k}`, v])),
+      ...annotations
+    }
+  }
+
+  if (payload?.commonLabels) {
+    annotations = {
+      ...Object.fromEntries(Object.entries(payload.commonLabels).map(([k, v]) => [`alertmanager/labels-${k}`, v])),
+      ...annotations
+    };
+  }
+
+  if (payload?.groupLabels) {
+    annotations = {
+      ...Object.fromEntries(Object.entries(payload.groupLabels).map(([k, v]) => [`alertmanager/grouped-by-${k}`, v])),
+      ...annotations
+    }
+  }
+
+  // If one alert in array, use that alert's info
+  // If multiple, hard-code summary
+  if (payload.alerts && payload.alerts.length > 0) {
+    if (payload.alerts.length === 1) {
+      summary = payload.alerts[0]?.annotations?.summary ? payload.alerts[0].annotations.summary : `Alert from ${payload.receiver}`;
+    } else {
+      summary = `${payload.alerts.length} alerts from ${payload.receiver}`;
+    }
+
+    // Summarize all alert titles/descriptions in body
+    payload.alerts.forEach((alert) => {
+      body += `${alert?.annotations?.summary}: ${alert?.annotations?.description}\n`;
+    });
+
+  } else {
+    // If no alerts in array, hardcode a summary/body
+    summary = `Alert from ${payload.receiver}`;
+    body = `${payload.receiver} sent a webhook without any alerts or other information.`;
+  }
+  
+  // Construct the Signal and return
+  let signal = {
+    idempotency_key: md5(payload.groupKey),
+    summary: summary,
+    body: body,
+    status: payload.status == 'firing' ? 0 : 1,
+    links: links,
+    annotations: annotations
+  };
+
+  return signal;
+}
+// COPY TO HERE //
+//////////////////
+module.exports = {
+  transpose
+}

--- a/src/cases/alertmanager/empty-open.expected.json
+++ b/src/cases/alertmanager/empty-open.expected.json
@@ -1,0 +1,10 @@
+{
+  "summary": "Alert from Receiver String",
+  "body": "Receiver String sent a webhook without any alerts or other information.",
+  "idempotency_key": "25f9e794323b453885f5181f1b624d0b",
+  "status": 0,
+  "links": [],
+  "annotations": {
+    "alertmanager/groupKey": "123456789"
+  }
+}

--- a/src/cases/alertmanager/empty-open.input.json
+++ b/src/cases/alertmanager/empty-open.input.json
@@ -1,0 +1,10 @@
+{
+  "version": "4",
+  "groupKey": "123456789",
+  "truncatedAlerts": 0,
+  "status": "firing",
+  "receiver": "Receiver String",
+  "externalURL": "https://test-alermanager.io",
+  "alerts": [
+  ]
+}

--- a/src/cases/alertmanager/multi-open.expected.json
+++ b/src/cases/alertmanager/multi-open.expected.json
@@ -1,0 +1,25 @@
+{
+  "summary": "2 alerts from Receiver String",
+  "body": "This is a test alertmanager alert: This is a longer description of a test alertmanager alert\nThis is another test alertmanager alert: This is a longer description of another test alertmanager alert\n",
+  "links": [
+    {
+      "href": "https://test-alermanager.io/generator",
+      "text": "Generator URL - This is a test alertmanager alert"
+    },
+    {
+      "href": "https://test-alermanager.io/generator",
+      "text": "Generator URL - This is another test alertmanager alert"
+    }
+  ],
+  "idempotency_key": "25f9e794323b453885f5181f1b624d0b",
+  "annotations": {
+    "alertmanager/annotations-commonAnnotation1": "value1",
+    "alertmanager/annotations-commonAnnotation2": "value2",
+    "alertmanager/groupKey": "123456789",
+    "alertmanager/grouped-by-groupLabel1": "value1",
+    "alertmanager/grouped-by-groupLabel2": "value2",
+    "alertmanager/labels-commonLabel1": "value1",
+    "alertmanager/labels-commonLabel2": "value2"
+  },
+  "status": 0
+}

--- a/src/cases/alertmanager/multi-open.input.json
+++ b/src/cases/alertmanager/multi-open.input.json
@@ -1,0 +1,56 @@
+{
+  "version": "4",
+  "groupKey": "123456789",
+  "truncatedAlerts": 0,
+  "status": "firing",
+  "receiver": "Receiver String",
+  "groupLabels": {
+    "groupLabel1": "value1",
+    "groupLabel2": "value2"
+  },
+  "commonLabels": {
+    "commonLabel1": "value1",
+    "commonLabel2": "value2"
+  },
+  "commonAnnotations": {
+    "commonAnnotation1": "value1",
+    "commonAnnotation2": "value2"
+  },
+  "externalURL": "https://test-alermanager.io",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "label1": "value1",
+        "label2": "value2"
+      },
+      "annotations": {
+        "summary": "This is a test alertmanager alert",
+        "description": "This is a longer description of a test alertmanager alert",
+        "annotation1": "value1",
+        "annotation2": "value2"
+      },
+      "startsAt": "2023-12-18T07:20:50.52Z",
+      "endsAt": "2023-12-18T07:20:50.52Z",
+      "generatorURL": "https://test-alermanager.io/generator",
+      "fingerprint": "28295wtbgwyrgb8731"
+    },
+    {
+      "status": "firing",
+      "labels": {
+        "label1": "value1",
+        "label2": "value2"
+      },
+      "annotations": {
+        "summary": "This is another test alertmanager alert",
+        "description": "This is a longer description of another test alertmanager alert",
+        "annotation1": "value1",
+        "annotation2": "value2"
+      },
+      "startsAt": "2023-12-18T07:20:50.52Z",
+      "endsAt": "2023-12-18T07:20:50.52Z",
+      "generatorURL": "https://test-alermanager.io/generator",
+      "fingerprint": "28295wtbgwyrgb8731"
+    }
+  ]
+}

--- a/src/cases/alertmanager/single-open.expected.json
+++ b/src/cases/alertmanager/single-open.expected.json
@@ -1,0 +1,21 @@
+{
+  "summary": "This is a test alertmanager alert",
+  "body": "This is a test alertmanager alert: This is a longer description of a test alertmanager alert\n",
+  "links": [
+    {
+      "href": "https://test-alermanager.io/generator",
+      "text": "Generator URL - This is a test alertmanager alert"
+    }
+  ],
+  "idempotency_key": "25f9e794323b453885f5181f1b624d0b",
+  "annotations": {
+    "alertmanager/annotations-commonAnnotation1": "value1",
+    "alertmanager/annotations-commonAnnotation2": "value2",
+    "alertmanager/groupKey": "123456789",
+    "alertmanager/grouped-by-groupLabel1": "value1",
+    "alertmanager/grouped-by-groupLabel2": "value2",
+    "alertmanager/labels-commonLabel1": "value1",
+    "alertmanager/labels-commonLabel2": "value2"
+  },
+  "status": 0
+}

--- a/src/cases/alertmanager/single-open.input.json
+++ b/src/cases/alertmanager/single-open.input.json
@@ -1,0 +1,39 @@
+{
+  "version": "4",
+  "groupKey": "123456789",
+  "truncatedAlerts": 0,
+  "status": "firing",
+  "receiver": "Receiver String",
+  "groupLabels": {
+    "groupLabel1": "value1",
+    "groupLabel2": "value2"
+  },
+  "commonLabels": {
+    "commonLabel1": "value1",
+    "commonLabel2": "value2"
+  },
+  "commonAnnotations": {
+    "commonAnnotation1": "value1",
+    "commonAnnotation2": "value2"
+  },
+  "externalURL": "https://test-alermanager.io",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "label1": "value1",
+        "label2": "value2"
+      },
+      "annotations": {
+        "summary": "This is a test alertmanager alert",
+        "description": "This is a longer description of a test alertmanager alert",
+        "annotation1": "value1",
+        "annotation2": "value2"
+      },
+      "startsAt": "2023-12-18T07:20:50.52Z",
+      "endsAt": "2023-12-18T07:20:50.52Z",
+      "generatorURL": "https://test-alermanager.io/generator",
+      "fingerprint": "28295wtbgwyrgb8731"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- If there are no alerts in the array of alerts from Alertmanager:
  - Summary will say "Alert from {receiver name}" instead of just "{receiver name}"
  - Description/Body will say "{receiver name} sent a webhook without any alerts or other information"
- If there is only one alert in the array:
  - Summary of FireHydrant alert will be the summary of the one alert (unchanged from CEL transposer)
  - Body of FireHydrant alert will be "{alert summary}: {alert description}\n"
- If there are multiple alerts in the array:
  - Summary will be "{number} alerts from {receiver name}"
  - Body of FireHydrant alert will be "{alert summary}: {alert description}\n" for every alert in array

Rather than summarizing multiple alerts only by the first alert's title and description (current behavior), we are including all alert summaries and bodies. The intention is to provide more clarity for multi-alert scenarios.

Annotations, links, and other param behaviors remain unchanged from CEL transposer.