### PR TITLE
Datadog transposer, but with modifications:

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -8,6 +8,10 @@
     "cases": ["open"]
   },
   {
+    "name": "datadog",
+    "cases": ["open-high", "open-low", "tag-list", "tag-none", "level-unknown"]
+  },
+  {
     "name": "fastly",
     "cases": ["open"]
   },

--- a/src/cases/datadog/level-unknown.expected.json
+++ b/src/cases/datadog/level-unknown.expected.json
@@ -1,0 +1,23 @@
+{
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "level": 0,
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "images": [
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "tags": [],
+  "idempotency_key": "18913k2b63ifs",
+  "status": 1,
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH"
+  }
+}

--- a/src/cases/datadog/level-unknown.input.json
+++ b/src/cases/datadog/level-unknown.input.json
@@ -1,0 +1,25 @@
+{
+  "unique_key": "18913k2b63ifs",
+  "level": "what???",
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "annotations": {},
+  "images": [
+    {
+      "src": "null",
+      "alt": "This should not come through"
+    },
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "status": "Recovered",
+  "received_at": "2023-11-08T21:56:54.000+00:00"
+}

--- a/src/cases/datadog/open-high.expected.json
+++ b/src/cases/datadog/open-high.expected.json
@@ -1,0 +1,24 @@
+{
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "level": 1,
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "images": [
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "tags": ["monitor", "name:myService", "role:computing-node", "region:us-west2"],
+  "idempotency_key": "18913k2b63ifs",
+  "status": 0,
+  "annotations": {
+    "datadog/priority": "P2",
+    "signals.firehydrant.com/notification-priority": "HIGH"
+  }
+}

--- a/src/cases/datadog/open-high.input.json
+++ b/src/cases/datadog/open-high.input.json
@@ -1,0 +1,28 @@
+{
+  "unique_key": "18913k2b63ifs",
+  "level": "warning",
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "annotations": {
+    "datadog/priority": "P2"
+  },
+  "images": [
+    {
+      "src": "null",
+      "alt": "This should not come through"
+    },
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "tags": "monitor, name:myService, role:computing-node, region:us-west2",
+  "status": "Triggered",
+  "received_at": "2023-11-08T21:56:54.000+00:00"
+}

--- a/src/cases/datadog/open-low.expected.json
+++ b/src/cases/datadog/open-low.expected.json
@@ -1,0 +1,24 @@
+{
+  "summary": "[P4] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "level": 1,
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "images": [
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P4] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "tags": ["monitor", "name:myService", "role:computing-node", "region:us-west2"],
+  "idempotency_key": "18913k2b63ifs",
+  "status": 0,
+  "annotations": {
+    "datadog/priority": "P4",
+    "signals.firehydrant.com/notification-priority": "LOW"
+  }
+}

--- a/src/cases/datadog/open-low.input.json
+++ b/src/cases/datadog/open-low.input.json
@@ -1,0 +1,28 @@
+{
+  "unique_key": "18913k2b63ifs",
+  "level": "warning",
+  "summary": "[P4] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "annotations": {
+    "datadog/priority": "P4"
+  },
+  "images": [
+    {
+      "src": "null",
+      "alt": "This should not come through"
+    },
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P4] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "tags": "monitor, name:myService, role:computing-node, region:us-west2",
+  "status": "Triggered",
+  "received_at": "2023-11-08T21:56:54.000+00:00"
+}

--- a/src/cases/datadog/tag-list.expected.json
+++ b/src/cases/datadog/tag-list.expected.json
@@ -1,0 +1,23 @@
+{
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "level": 1,
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "images": [
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "tags": ["monitor", "name:myService", "role:computing-node", "region:us-west2"],
+  "idempotency_key": "18913k2b63ifs",
+  "status": 1,
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH"
+  }
+}

--- a/src/cases/datadog/tag-list.input.json
+++ b/src/cases/datadog/tag-list.input.json
@@ -1,0 +1,26 @@
+{
+  "unique_key": "18913k2b63ifs",
+  "level": "warning",
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "annotations": {},
+  "images": [
+    {
+      "src": "null",
+      "alt": "This should not come through"
+    },
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "tags": ["monitor", "name:myService", "role:computing-node", "region:us-west2"],
+  "status": "Recovered",
+  "received_at": "2023-11-08T21:56:54.000+00:00"
+}

--- a/src/cases/datadog/tag-none.expected.json
+++ b/src/cases/datadog/tag-none.expected.json
@@ -1,0 +1,23 @@
+{
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "level": 1,
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "images": [
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "tags": [],
+  "idempotency_key": "18913k2b63ifs",
+  "status": 1,
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH"
+  }
+}

--- a/src/cases/datadog/tag-none.input.json
+++ b/src/cases/datadog/tag-none.input.json
@@ -1,0 +1,25 @@
+{
+  "unique_key": "18913k2b63ifs",
+  "level": "warning",
+  "summary": "[P2] [Triggered] [TEST] Test Monitor",
+  "body": "This is the content of the monitor.",
+  "annotations": {},
+  "images": [
+    {
+      "src": "null",
+      "alt": "This should not come through"
+    },
+    {
+      "src": "https://example.com/pic.png",
+      "alt": "Snapshot from [P2] [Triggered] [TEST] Signals Test Monitor"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://datadoghq.com/event/event?id=238472398472582",
+      "text": "Datadog Monitor"
+    }
+  ],
+  "status": "Recovered",
+  "received_at": "2023-11-08T21:56:54.000+00:00"
+}

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -1,0 +1,78 @@
+////////////////////
+// COPY FROM HERE //
+/**
+ * Translates from Datadog level to FH level.
+ * See: https://docs.firehydrant.com/docs/events-data-model
+ */
+function getLevel(level) {
+  if (level) {
+    switch (level) {
+      case 'error':
+        return 2;
+      case 'warning':
+        return 1;
+      default:
+        return 0;
+    }
+  }
+
+  return 0; // INFO
+}
+
+/**
+ * Translates from Datadog priority (P*) to FH level.
+ * This assumes default behavior but can be modified.
+ */
+function getPriority(priority) {
+  if (priority) {
+    switch (priority) {
+      case 'P1':
+      case 'P2':
+        return 'HIGH';
+      default:
+        return 'LOW';
+    }
+  }
+
+  return 'HIGH'; // Defaults to high priority
+}
+
+/*
+ * Transpose a payload into a Signal
+ */
+function transpose(input) {
+  const payload = input.data;
+  let tags = [];
+
+  // Apparently Tags can be comma-delimited string OR an
+  // array of strings... why wtf
+  if (payload?.tags) {
+    if (typeof payload.tags === 'string') {
+      tags = payload.tags.split(',').map(tag => tag.trim())
+    } else if (typeof payload.tags === 'object' && payload.tags.constructor === Array) {
+      tags = payload.tags;
+    }
+  }
+
+  let signal = {
+    idempotency_key: payload?.unique_key ? payload.unique_key : (payload?.summary ? payload.summary : ''),
+    summary: payload?.summary ? payload.summary : 'Alert from Datadog',
+    body: payload?.body ? payload.body : 'No information provided',
+    level: getLevel(payload?.level),
+    links: payload?.links ? payload.links : [],
+    images: payload?.images.filter((link) => link.src !== 'null'),
+    tags: tags,
+    status: payload?.status && payload.status === 'Recovered' ? 1 : 0,
+    annotations: {
+      'signals.firehydrant.com/notification-priority': getPriority(payload?.annotations?.['datadog/priority']),
+      ...(payload?.annotations || {})
+    }
+  };
+
+  return signal;
+}
+// COPY TO HERE //
+//////////////////
+module.exports = {
+  transpose
+}


### PR DESCRIPTION
## Summary

Almost all functionality from CEL transposer is preserved, but some new behaviors were added:

- We now set FH notification priority based on a Datadog priority
  - Default is P1, P2 -> HIGH, everything else LOW
- We also insert Datadog priority as its own annotation `datadog/priority`, updated docs for setting webhook format in Datadog