### PR TITLE
Add Chronosphere transposer in js

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -8,6 +8,10 @@
     "cases": ["open", "confirm"]
   },
   {
+    "name": "chronosphere",
+    "cases": ["open"]
+  },
+  {
     "name": "conviva",
     "cases": ["open"]
   },

--- a/src/cases/chronosphere/open.expected.json
+++ b/src/cases/chronosphere/open.expected.json
@@ -1,0 +1,21 @@
+{
+  "summary": "test alert",
+  "body": "Alert from Chronosphere via test-policy: test alert",
+  "idempotency_key": "7424223989b20025",
+  "annotations": {
+    "chronosphere/annotation-monitor_slug": "test-monitor",
+    "chronosphere/annotation-notification_policy_slug": "test-policy",
+    "chronosphere/annotation-ruleid": "32bb3fbe-c10b-44bb-a4c0-3d053f4a08cd",
+    "chronosphere/commonlabel-alertname": "test alert",
+    "chronosphere/commonlabel-component": "remote_write",
+    "chronosphere/commonlabel-instance": "localhost:3030",
+    "chronosphere/commonlabel-job": "collector_binary",
+    "chronosphere/commonlabel-pod_name": "prom-74cbfb46c9-2ftk9",
+    "chronosphere/commonlabel-severity": "critical",
+    "chronosphere/grouplabel-alertname": "test alert",
+    "chronosphere/grouplabel-severity": "critical",
+    "chronosphere/notifier": "test webhook",
+    "chronosphere/status": "firing"
+  },
+  "status": 0
+}

--- a/src/cases/chronosphere/open.input.json
+++ b/src/cases/chronosphere/open.input.json
@@ -1,0 +1,43 @@
+{
+  "notifier": "test webhook",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "test alert",
+        "component": "remote_write",
+        "instance": "localhost:3030",
+        "job": "collector_binary",
+        "severity": "critical",
+        "pod_name": "prom-74cbfb46c9-2ftk9"
+      },
+      "annotations": {
+        "ruleid": "32bb3fbe-c10b-44bb-a4c0-3d053f4a08cd",
+        "monitor_slug": "test-monitor",
+        "notification_policy_slug": "test-policy"
+      },
+      "startsAt": "2020-05-19T13:57:21.68227886Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "fingerprint": "7424223989b20025"
+    }
+  ],
+  "groupLabels": {
+    "alertname": "test alert",
+    "severity": "critical"
+  },
+  "commonLabels": {
+    "alertname": "test alert",
+    "component": "remote_write",
+    "instance": "localhost:3030",
+    "job": "collector_binary",
+    "severity": "critical",
+    "pod_name": "prom-74cbfb46c9-2ftk9"
+  },
+  "commonAnnotations": {
+    "ruleid": "32bb3fbe-c10b-44bb-a4c0-3d053f4a08cd",
+    "monitor_slug": "test-monitor",
+    "notification_policy_slug": "test-policy"
+  },
+  "version": "4"
+}

--- a/src/chronosphere.js
+++ b/src/chronosphere.js
@@ -1,0 +1,38 @@
+////////////////////
+// COPY FROM HERE //
+/*
+ * Transpose Chronosphere payload into a Signal
+ */
+function transpose(input) {
+  const payload = input.data;
+
+  let annotations = {
+    'chronosphere/notifier': payload?.notifier || '',
+    'chronosphere/status': payload?.status
+  };
+
+  // Append all the group labels, common labels, and common annotations
+  for (const [key, value] of Object.entries(payload?.groupLabels)) {
+    annotations[`chronosphere/grouplabel-${key}`] = value;
+  }
+  for (const [key, value] of Object.entries(payload?.commonLabels)) {
+    annotations[`chronosphere/commonlabel-${key}`] = value;
+  }
+  for (const [key, value] of Object.entries(payload?.commonAnnotations)) {
+    annotations[`chronosphere/annotation-${key}`] = value;
+  }
+
+  let signal = {
+    idempotency_key: payload?.alerts[0]?.fingerprint,
+    summary: payload?.commonLabels?.alertname || "No alert name provided",
+    body: `Alert from Chronosphere via ${payload?.commonAnnotations?.notification_policy_slug}: ${payload?.commonLabels?.alertname}`,
+    status: payload?.status === 'firing' ? 0 : 1,
+    annotations: annotations
+  };
+  return signal;
+}
+// COPY TO HERE //
+//////////////////
+module.exports = {
+  transpose
+}


### PR DESCRIPTION
## Summary

Implemented Chronosphere transposer in Javascript. There are a few changes compared to our CEL-based transposer for Chronosphere in prod today:

- Transposed annotations are different and will include groupLabels, commonLabels, and commonAnnotations from Chronosphere. The respective keys will be `chronosphere/grouplabel-*`, `chronosphere/commonlabel-*`, and `chronosphere/annotation-*`.
- We also transpose more annotations, including `notifier` and `status`
- The FireHydrant `status` parameter is explicitly set to OPEN if the status from Chronosphere is `firing`, all else is set to CLOSED.
- The body of the alert is now `Alert from Chronosphere via ${notification_policy_slug}: ${alert name}`, as opposed to just "No information provided" in the current implementation