### PR TITLE
Transposer/pingdom

### DIFF
--- a/cases.json
+++ b/cases.json
@@ -34,5 +34,9 @@
   {
     "name": "pd-v2",
     "cases": ["open", "resolve"]
+  },
+  {
+    "name": "pingdom",
+    "cases": ["open_http", "open_http_custom", "open_tcp", "open_ping", "open_dns", "open_udp", "open_smtp"]
   }
 ]

--- a/cases.json
+++ b/cases.json
@@ -37,6 +37,6 @@
   },
   {
     "name": "pingdom",
-    "cases": ["open_http", "open_http_custom", "open_tcp", "open_ping", "open_dns", "open_udp", "open_smtp"]
+    "cases": ["open_http", "open_http_custom", "open_tcp", "open_ping", "open_dns", "open_udp", "open_smtp", "close_transaction_check"]
   }
 ]

--- a/src/cases/pingdom/close_transaction_check.expected.json
+++ b/src/cases/pingdom/close_transaction_check.expected.json
@@ -1,0 +1,25 @@
+{
+  "summary": "[Recovery] Error message",
+  "body": "No long description provided",
+  "level": 2,
+  "links": [],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "check_id": "12345",
+    "check_name": "Name of transaction check",
+    "check_type": "TRANSACTION",
+    "current_state": "SUCCESS",
+    "encryption": "true",
+    "importance_level": "HIGH",
+    "port": "443",
+    "previous_state": "FAILING",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01",
+    "url": "https://www.example.com/"
+  },
+  "idempotency_key": "12345",
+  "status": 1
+}
+

--- a/src/cases/pingdom/close_transaction_check.input.json
+++ b/src/cases/pingdom/close_transaction_check.input.json
@@ -1,0 +1,30 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of transaction check",
+  "check_type": "TRANSACTION",
+  "check_params": {
+    "encryption": true,
+    "port": 443,
+    "url": "https://www.example.com/"
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "FAILING",
+  "current_state": "SUCCESS",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "description": "Error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_dns.expected.json
+++ b/src/cases/pingdom/open_dns.expected.json
@@ -1,0 +1,31 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of DNS check",
+    "check_type": "DNS",
+    "current_state": "DOWN",
+    "expected_ip": "123.4.5.6",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "nameserver": "example.com",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_dns.input.json
+++ b/src/cases/pingdom/open_dns.input.json
@@ -1,0 +1,33 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of DNS check",
+  "check_type": "DNS",
+  "check_params": {
+    "hostname": "www.example.com",
+    "basic_auth": false,
+    "expected_ip": "123.4.5.6",
+    "ipv6": false,
+    "nameserver": "example.com"
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_http.expected.json
+++ b/src/cases/pingdom/open_http.expected.json
@@ -1,0 +1,34 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of HTTP check",
+    "check_type": "HTTP",
+    "current_state": "DOWN",
+    "encryption": "true",
+    "full_url": "https://www.example.com/path",
+    "header": "User-Agent:Pingdom.com_bot",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "port": "443",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01",
+    "url": "/path"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_http.input.json
+++ b/src/cases/pingdom/open_http.input.json
@@ -1,0 +1,36 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of HTTP check",
+  "check_type": "HTTP",
+  "check_params": {
+    "basic_auth": false,
+    "encryption": true,
+    "full_url": "https://www.example.com/path",
+    "header": "User-Agent:Pingdom.com_bot",
+    "hostname": "www.example.com",
+    "ipv6": false,
+    "port": 443,
+    "url": "/path"
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_http_custom.expected.json
+++ b/src/cases/pingdom/open_http_custom.expected.json
@@ -1,0 +1,33 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of HTTP Custom check",
+    "check_type": "HTTP_CUSTOM",
+    "current_state": "DOWN",
+    "encryption": "false",
+    "full_url": "https://www.example.com/path",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "port": "80",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01",
+    "url": "/"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_http_custom.input.json
+++ b/src/cases/pingdom/open_http_custom.input.json
@@ -1,0 +1,35 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of HTTP Custom check",
+  "check_type": "HTTP_CUSTOM",
+  "check_params": {
+    "basic_auth": false,
+    "encryption": false,
+    "full_url": "https://www.example.com/path",
+    "hostname": "www.example.com",
+    "ipv6": false,
+    "port": 80,
+    "url": "/"
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_ping.expected.json
+++ b/src/cases/pingdom/open_ping.expected.json
@@ -1,0 +1,29 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of Ping check",
+    "check_type": "PING",
+    "current_state": "DOWN",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_ping.input.json
+++ b/src/cases/pingdom/open_ping.input.json
@@ -1,0 +1,31 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of Ping check",
+  "check_type": "PING",
+  "check_params": {
+    "hostname": "www.example.com",
+    "basic_auth": false,
+    "ipv6": false
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_smtp.expected.json
+++ b/src/cases/pingdom/open_smtp.expected.json
@@ -1,0 +1,31 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "123456",
+    "check_name": "Name of SMTP check",
+    "check_type": "SMTP",
+    "current_state": "DOWN",
+    "encryption": "false",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "port": "25",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01"
+  },
+  "idempotency_key": "123456",
+  "status": 0
+}

--- a/src/cases/pingdom/open_smtp.input.json
+++ b/src/cases/pingdom/open_smtp.input.json
@@ -1,0 +1,33 @@
+{
+  "check_id": 123456,
+  "check_name": "Name of SMTP check",
+  "check_type": "SMTP",
+  "check_params": {
+    "basic_auth": false,
+    "encryption": false,
+    "hostname": "www.example.com",
+    "ipv6": false,
+    "port": 25
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_tcp.expected.json
+++ b/src/cases/pingdom/open_tcp.expected.json
@@ -1,0 +1,30 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of TCP check",
+    "check_type": "PORT_TCP",
+    "current_state": "DOWN",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "port": "80",
+    "previous_state": "UP",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_tcp.input.json
+++ b/src/cases/pingdom/open_tcp.input.json
@@ -1,0 +1,32 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of TCP check",
+  "check_type": "PORT_TCP",
+  "check_params": {
+    "hostname": "www.example.com",
+    "basic_auth": false,
+    "ipv6": false,
+    "port": 80
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/cases/pingdom/open_udp.expected.json
+++ b/src/cases/pingdom/open_udp.expected.json
@@ -1,0 +1,32 @@
+{
+  "summary": "Short error message",
+  "body": "Long error message",
+  "level": 2,
+  "links": [
+    {
+      "href": "www.example.com",
+      "alt": "Check Host"
+    }
+  ],
+  "images": [],
+  "tags": ["example_tag"],
+  "annotations": {
+    "signals.firehydrant.com/notification-priority": "HIGH",
+    "basic_auth": "false",
+    "check_id": "12345",
+    "check_name": "Name of UDP check",
+    "check_type": "UDP",
+    "current_state": "DOWN",
+    "expect": "string to expect",
+    "hostname": "www.example.com",
+    "importance_level": "HIGH",
+    "ipv6": "false",
+    "port": "80",
+    "previous_state": "UP",
+    "send": "string to send",
+    "state_changed_timestamp": "1451610061",
+    "state_changed_utc_time": "2016-01-01T01:01:01"
+  },
+  "idempotency_key": "12345",
+  "status": 0
+}

--- a/src/cases/pingdom/open_udp.input.json
+++ b/src/cases/pingdom/open_udp.input.json
@@ -1,0 +1,34 @@
+{
+  "check_id": 12345,
+  "check_name": "Name of UDP check",
+  "check_type": "UDP",
+  "check_params": {
+    "hostname": "www.example.com",
+    "basic_auth": false,
+    "expect": "string to expect",
+    "ipv6": false,
+    "port": 80,
+    "send": "string to send"
+  },
+  "tags": [
+    "example_tag"
+  ],
+  "previous_state": "UP",
+  "current_state": "DOWN",
+  "importance_level": "HIGH",
+  "state_changed_timestamp": 1451610061,
+  "state_changed_utc_time": "2016-01-01T01:01:01",
+  "long_description": "Long error message",
+  "description": "Short error message",
+  "first_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Stockholm, Sweden"
+  },
+  "second_probe": {
+    "ip": "123.4.5.6",
+    "ipv6": "2001:4800:1020:209::5",
+    "location": "Austin, US",
+    "version": 1
+  }
+}

--- a/src/pingdom.js
+++ b/src/pingdom.js
@@ -32,33 +32,8 @@ function importanceToLevel(importance) {
  * Check for these annotation keys and insert if available
  */
 function getAnnotations(payload) {
-  let optionalKeys = [];
-
-  switch (payload.check_type) {
-    case 'HTTP':
-      optionalKeys.push('basic_auth', 'encryption', 'full_url', 'header', 'hostname', 'ipv6', 'port', 'url');
-      break;
-    case 'HTTP_CUSTOM':
-      optionalKeys.push('basic_auth', 'encryption', 'full_url', 'hostname', 'ipv6', 'port', 'url');
-      break;
-    case 'PORT_TCP':
-      optionalKeys.push('basic_auth', 'hostname', 'ipv6', 'port');
-      break;
-    case 'PING':
-      optionalKeys.push('basic_auth', 'hostname', 'ipv6');
-      break;
-    case 'DNS':
-      optionalKeys.push('basic_auth', 'expected_ip', 'hostname', 'ipv6', 'nameserver');
-      break;
-    case 'UDP':
-      optionalKeys.push('basic_auth', 'expect', 'hostname', 'ipv6', 'port', 'send');
-      break;
-    case 'SMTP':
-    case 'POP3':
-    case 'IMAP':
-      optionalKeys.push('basic_auth', 'encryption', 'hostname', 'ipv6', 'port');
-      break;
-  }
+  // Include all optional keys that may or may not exist based on type of check
+  const optionalKeys = ['basic_auth', 'encryption', 'expect', 'expected_ip', 'full_url', 'header', 'hostname', 'ipv6', 'nameserver', 'port', 'send', 'url'];
 
   const optionalAnnotations = optionalKeys.reduce((acc, key) => {
     // Only add the key if it exists in check_params

--- a/src/pingdom.js
+++ b/src/pingdom.js
@@ -1,0 +1,117 @@
+////////////////////
+// COPY FROM HERE //
+/**
+ * Translates Pingdom importance_level to FH priority
+ */
+function importanceToPriority(importance) {
+  switch (importance) {
+    case 'CRITICAL':
+      return 'HIGH';
+    default:
+      return importance; // Pingdom also uses HIGH/MEDIUM/LOW
+  }
+}
+
+/**
+ * Translates Pingdom importance_level to FH level 
+ */
+function importanceToLevel(importance) {
+  switch (importance) {
+    case 'CRITICAL':
+      return 3;
+    case 'HIGH':
+      return 2;
+    case 'MEDIUM':
+      return 1;
+    default:
+      return 0; // Log INFO by default
+  }
+}
+
+/**
+ * Check for these annotation keys and insert if available
+ */
+function getAnnotations(payload) {
+  let optionalKeys = [];
+
+  switch (payload.check_type) {
+    case 'HTTP':
+      optionalKeys.push('basic_auth', 'encryption', 'full_url', 'header', 'hostname', 'ipv6', 'port', 'url');
+      break;
+    case 'HTTP_CUSTOM':
+      optionalKeys.push('basic_auth', 'encryption', 'full_url', 'hostname', 'ipv6', 'port', 'url');
+      break;
+    case 'PORT_TCP':
+      optionalKeys.push('basic_auth', 'hostname', 'ipv6', 'port');
+      break;
+    case 'PING':
+      optionalKeys.push('basic_auth', 'hostname', 'ipv6');
+      break;
+    case 'DNS':
+      optionalKeys.push('basic_auth', 'expected_ip', 'hostname', 'ipv6', 'nameserver');
+      break;
+    case 'UDP':
+      optionalKeys.push('basic_auth', 'expect', 'hostname', 'ipv6', 'port', 'send');
+      break;
+    case 'SMTP':
+    case 'POP3':
+    case 'IMAP':
+      optionalKeys.push('basic_auth', 'encryption', 'hostname', 'ipv6', 'port');
+      break;
+  }
+
+  const optionalAnnotations = optionalKeys.reduce((acc, key) => {
+    // Only add the key if it exists in check_params
+    if (payload.check_params && payload.check_params[key] !== undefined) {
+      acc[key] = String(payload.check_params[key]);
+    }
+    return acc;
+  }, {});
+
+  let annotations = {
+    'signals.firehydrant.com/notification-priority': importanceToPriority(payload.importance_level),
+    check_id: String(payload.check_id),
+    check_name: payload.check_name,
+    check_type: payload.check_type,
+    current_state: payload.current_state,
+    importance_level: payload.importance_level,
+    previous_state: payload?.previous_state || '',
+    state_changed_timestamp: String(payload.state_changed_timestamp),
+    state_changed_utc_time: payload.state_changed_utc_time,
+    ...optionalAnnotations // Spread the optional annotations into the main annotations object
+  };
+  
+  return annotations; // Don't forget to return the annotations
+}
+
+/*
+ * Transpose a payload into a Signal
+ */
+function transpose(input) {
+  const payload = input.data;
+  let links = [];
+
+  if (payload?.check_params?.hostname) {
+    links.push({
+      href: payload.check_params.hostname,
+      alt: 'Check Host'
+    });
+  }
+
+  return {
+    idempotency_key: String(payload?.check_id),
+    summary: payload?.description || `Pingdom Alert for ${payload.check_name}`,
+    body: payload?.long_description || 'No long description provided',
+    images: [],
+    level: importanceToLevel(payload.importance_level),
+    links: links,
+    tags: payload?.tags || [],
+    annotations: getAnnotations(payload),
+    status: (payload.current_state === "DOWN" || payload.current_state === "FAILING") ? 0 : 1
+  };
+}
+// COPY TO HERE //
+//////////////////
+module.exports = {
+  transpose
+}

--- a/src/pingdom.js
+++ b/src/pingdom.js
@@ -75,7 +75,7 @@ function transpose(input) {
 
   return {
     idempotency_key: String(payload?.check_id),
-    summary: payload?.description || `Pingdom Alert for ${payload.check_name}`,
+    summary: (payload?.current_state === 'SUCCESS' || payload?.current_state === 'UP' ? '[Recovery] ' : '') + payload?.description || `Pingdom Alert for ${payload.check_name}`,
     body: payload?.long_description || 'No long description provided',
     images: [],
     level: importanceToLevel(payload.importance_level),


### PR DESCRIPTION
Add Pingdom transposer to JS. Some slight modifications compared to current out-of-box transposer:

- Sets both level and priority based on the importance level from Pingdom
  - Priority is HIGH if importance is CRITICAL or HIGH. Otherwise will also be MEDIUM or LOW
  - Level is now FATAL if importance is CRITICAL, ERROR if importance is HIGH, WARN if importance is MEDIUM, and INFO if importance is LOW
- Handles all types of Pingdom checks (e.g., will have different annotations according to available check_params, which changes based on the type of check)
- Handles Transaction checks, including "SUCCESS" state as a recovery state
- Sets the title of the event to include [Recovery] if it's a recovery alert
- Includes `hostname` as a link where applicable